### PR TITLE
Fix for having only 1 page of gists

### DIFF
--- a/gists.rb
+++ b/gists.rb
@@ -16,7 +16,7 @@ class Gists
     while next_page do
       response = Typhoeus.get("https://api.github.com/gists?page=#{next_page}&per_page=100", :userpwd => "#{@username}:#{@password}")
       p "Querying Gist API for page ##{next_page}"
-      next_page = response.headers_hash["Link"][/page=([0-9]+).+next/,1]
+      next_page = response.headers_hash["Link"].nil? ? false : response.headers_hash["Link"][/page=([0-9]+).+next/,1]
       JSON.parse(response.body).each do |gist|
         gists << Gist.new(gist)
       end


### PR DESCRIPTION
Hi! Thanks for the great tool! I ran into an issue where there was only 1 gists page and the importer would not work when setting next_page.

```
`get': undefined method `[]' for nil:NilClass (NoMethodError)
```

I don't know much (any actually) ruby, so I just took a generic approach and this seemed to have worked.

Cheers!
