### PR TITLE
Consolidate RUNs so that there's a root layer and a user layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,22 @@
 FROM ubuntu:14.04
 MAINTAINER Mark Percival <m@mdp.im>
 
-RUN apt-get update && apt-get install -y curl ruby-dev make libsqlite3-dev zip && gem install bundle --no-rdoc --no-ri
-RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apt-get update && \
+    apt-get install -y curl ruby-dev make libsqlite3-dev zip && \
+    gem install bundle --no-rdoc --no-ri && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    useradd -m evergist && \
+    mkdir /app && \
+    chown evergist /app
 
-RUN useradd -m evergist
-RUN mkdir /app && chown evergist /app
 USER evergist
 
 WORKDIR "/app"
-RUN curl -L -O https://github.com/mdp/GistEvernoteImport/archive/master.zip && unzip -j master.zip
-RUN bundle install --path /app/.gem
+
+RUN curl -L -O https://github.com/mdp/GistEvernoteImport/archive/master.zip && \
+    unzip -j master.zip && \
+    bundle install --path /app/.gem
 
 VOLUME ["/app/data"]
 


### PR DESCRIPTION
Each RUN command creates its own layer in the union filesystem. This is useful during development, but adds extra complexity at runtime.
